### PR TITLE
milestones for natural continuation

### DIFF
--- a/pacopy/natural.py
+++ b/pacopy/natural.py
@@ -82,10 +82,9 @@ def natural(
             )
 
         # Predictor
-        if milestones is None:
-            lmbda += lambda_stepsize
-        else:
-            lmbda = min(lmbda + lambda_stepsize, milestone)
+        lmbda += lambda_stepsize
+        if milestones:
+            lmbda = min(lmbda, milestone)
         if use_first_order_predictor:
             du_dlmbda = problem.jacobian_solver(u, lmbda, -problem.df_dlmbda(u, lmbda))
             u0 = u + du_dlmbda * lambda_stepsize

--- a/pacopy/natural.py
+++ b/pacopy/natural.py
@@ -46,7 +46,8 @@ def natural(
         milestones (Optional[Iterable[float]]): Don't step over these values.
     """
     lmbda = lambda0
-    milestones = iter([] if milestones is None else milestones)
+    if milestones is not None:
+        milestones = iter(milestones)
 
     k = 0
     try:

--- a/pacopy/natural.py
+++ b/pacopy/natural.py
@@ -108,13 +108,6 @@ def natural(
             lambda_stepsize /= 2
             continue
 
-        lambda_stepsize *= (
-            1
-            + lambda_stepsize_aggressiveness
-            * ((max_newton_steps - newton_steps) / (max_newton_steps - 1)) ** 2
-        )
-        lambda_stepsize = min(lambda_stepsize, lambda_stepsize_max)
-
         callback(k, lmbda, u)
         k += 1
         if milestones is not None and lmbda == milestone:
@@ -122,5 +115,12 @@ def natural(
                 milestone = next(milestones)
             except StopIteration:
                 break
+        else:
+            lambda_stepsize *= (
+                1
+                + lambda_stepsize_aggressiveness
+                * ((max_newton_steps - newton_steps) / (max_newton_steps - 1)) ** 2
+            )
+            lambda_stepsize = min(lambda_stepsize, lambda_stepsize_max)
 
     return

--- a/pacopy/natural.py
+++ b/pacopy/natural.py
@@ -48,8 +48,7 @@ def natural(
         milestones (Optional[Iterable[float]]): Don't step over these values.
     """
     lmbda = lambda0
-    milestones = deque(milestones if milestones is not None
-                       else [float("inf")])
+    milestones = deque(milestones if milestones is not None else [float("inf")])
 
     k = 0
     try:
@@ -70,7 +69,7 @@ def natural(
 
     lambda_stepsize = lambda_stepsize0
     milestone = milestones.popleft()
-    
+
     while True:
         if k > max_steps:
             break

--- a/pacopy/natural.py
+++ b/pacopy/natural.py
@@ -9,7 +9,7 @@ def natural(
     lambda0,
     callback,
     lambda_stepsize0=1.0e-1,
-    lambda_stepsize_max=1.0e0,
+    lambda_stepsize_max=float("inf"),
     lambda_stepsize_aggressiveness=2,
     max_newton_steps=5,
     newton_tol=1.0e-12,

--- a/pacopy/natural.py
+++ b/pacopy/natural.py
@@ -46,8 +46,7 @@ def natural(
         milestones (Optional[Iterable[float]]): Don't step over these values.
     """
     lmbda = lambda0
-    if milestones is not None:
-        lambdas = iter(milestones)
+    milestones = iter([] if milestones is None else milestones)
 
     k = 0
     try:
@@ -68,7 +67,7 @@ def natural(
 
     lambda_stepsize = lambda_stepsize0
     if milestones is not None:
-        milestone = next(lambdas)
+        milestone = next(milestones)
 
     while True:
         if k > max_steps:
@@ -119,7 +118,7 @@ def natural(
         k += 1
         if milestones is not None and lmbda == milestone:
             try:
-                milestone = next(lambdas)
+                milestone = next(milestones)
             except StopIteration:
                 break
 

--- a/test/test_bratu1d.py
+++ b/test/test_bratu1d.py
@@ -58,10 +58,6 @@ class Bratu1d(object):
         return scipy.sparse.linalg.spsolve(self.jacobian(u, lmbda), rhs)
 
 
-class RangeException(Exception):
-    pass
-
-
 def test_bratu(max_steps=10, update_plot=False):
     problem = Bratu1d()
     u0 = numpy.zeros(problem.n)
@@ -98,9 +94,6 @@ def test_bratu(max_steps=10, update_plot=False):
             ax1.set_xlim(0.0, 4.0)
             ax1.set_ylim(0.0, 6.0)
 
-            if ax1.get_ylim()[1] < val:
-                raise RangeException
-
             # ax1.plot([lmbda_pre], [numpy.sqrt(problem.inner(u_pre, u_pre))], ".r")
 
             # line2.set_ydata(sol)
@@ -127,15 +120,9 @@ def test_bratu(max_steps=10, update_plot=False):
 
     # The condition number of the Jacobian is about 10^4, so we can only expect Newton
     # to converge up to about this factor above machine precision.
-    try:
-        pacopy.euler_newton(
-            problem, u0, lmbda0, callback, max_steps=max_steps, newton_tol=1.0e-10
-        )
-    except RangeException:
-        if update_plot:
-            plt.pause(5)
-            profile_ax.legend()
-            profile_fig.savefig("bratu1d_profiles.png", bbox_inches="tight")
+    pacopy.euler_newton(
+        problem, u0, lmbda0, callback, max_steps=max_steps, newton_tol=1.0e-10
+    )
     return
 
 

--- a/test/test_bratu1d.py
+++ b/test/test_bratu1d.py
@@ -58,6 +58,10 @@ class Bratu1d(object):
         return scipy.sparse.linalg.spsolve(self.jacobian(u, lmbda), rhs)
 
 
+class RangeException(Exception):
+    pass
+
+
 def test_bratu(max_steps=10, update_plot=False):
     problem = Bratu1d()
     u0 = numpy.zeros(problem.n)
@@ -90,6 +94,9 @@ def test_bratu(max_steps=10, update_plot=False):
             ax1.set_xlim(0.0, 4.0)
             ax1.set_ylim(0.0, 6.0)
 
+            if ax1.get_ylim()[1] < val:
+                raise RangeException
+
             # ax1.plot([lmbda_pre], [numpy.sqrt(problem.inner(u_pre, u_pre))], ".r")
 
             # line2.set_ydata(sol)
@@ -101,13 +108,18 @@ def test_bratu(max_steps=10, update_plot=False):
             # plt.savefig('bratu1d.png'.format(k), transparent=True, bbox_inches="tight")
         return
 
-    pacopy.natural(problem, u0, lmbda0, callback, max_steps=max_steps)
+    pacopy.natural(problem, u0, lmbda0, callback, max_steps=max_steps,
+                   newton_tol=1e-10, milestones=numpy.arange(.5, 3.2, .5))
 
     # The condition number of the Jacobian is about 10^4, so we can only expect Newton
     # to converge up to about this factor above machine precision.
-    pacopy.euler_newton(
-        problem, u0, lmbda0, callback, max_steps=max_steps, newton_tol=1.0e-10
-    )
+    try:
+        pacopy.euler_newton(
+            problem, u0, lmbda0, callback, max_steps=max_steps, newton_tol=1.0e-10
+        )
+    except RangeException:
+        if update_plot:
+            plt.pause(5)
     return
 
 

--- a/test/test_bratu1d.py
+++ b/test/test_bratu1d.py
@@ -108,8 +108,15 @@ def test_bratu(max_steps=10, update_plot=False):
             # plt.savefig('bratu1d.png'.format(k), transparent=True, bbox_inches="tight")
         return
 
-    pacopy.natural(problem, u0, lmbda0, callback, max_steps=max_steps,
-                   newton_tol=1e-10, milestones=numpy.arange(.5, 3.2, .5))
+    pacopy.natural(
+        problem,
+        u0,
+        lmbda0,
+        callback,
+        max_steps=max_steps,
+        newton_tol=1e-10,
+        milestones=numpy.arange(0.5, 3.2, 0.5),
+    )
 
     # The condition number of the Jacobian is about 10^4, so we can only expect Newton
     # to converge up to about this factor above machine precision.

--- a/test/test_bratu1d.py
+++ b/test/test_bratu1d.py
@@ -84,6 +84,10 @@ def test_bratu(max_steps=10, update_plot=False):
     # line3, = ax2.plot([], [], "-", color="red")
     # line3.set_xdata(numpy.linspace(0.0, 1.0, problem.n))
 
+    milestones = numpy.arange(0.5, 3.2, 0.5)
+    if update_plot:
+        profile_fig, profile_ax = plt.subplots()
+
     def callback(k, lmbda, sol):
         if update_plot:
             line1.set_xdata(numpy.append(line1.get_xdata(), lmbda))
@@ -106,6 +110,9 @@ def test_bratu(max_steps=10, update_plot=False):
             fig.canvas.draw()
             fig.canvas.flush_events()
             # plt.savefig('bratu1d.png'.format(k), transparent=True, bbox_inches="tight")
+            if lmbda in milestones:
+                profile_ax.plot(numpy.linspace(0.0, 1.0, problem.n), sol, label=lmbda)
+
         return
 
     pacopy.natural(
@@ -115,7 +122,7 @@ def test_bratu(max_steps=10, update_plot=False):
         callback,
         max_steps=max_steps,
         newton_tol=1e-10,
-        milestones=numpy.arange(0.5, 3.2, 0.5),
+        milestones=milestones,
     )
 
     # The condition number of the Jacobian is about 10^4, so we can only expect Newton
@@ -127,6 +134,8 @@ def test_bratu(max_steps=10, update_plot=False):
     except RangeException:
         if update_plot:
             plt.pause(5)
+            profile_ax.legend()
+            profile_fig.savefig("bratu1d_profiles.png", bbox_inches="tight")
     return
 
 


### PR DESCRIPTION
Implemented using [`collections.deque`](https://docs.python.org/3/library/collections.html#collections.deque), though the parameter can be passed in as any `Iterable`, e.g. `numpy.ndarray` (with `ndim==1`), as in `test/test_bratu1d.py`, modified to demonstrate.

As discussed in #5, if milestones have been specified, the natural parameter continuation terminates after the last has been reached.

The overall effect can be seen in the (_&lambda;_, || _u_ ||²) plot, with an × on each vertical grid line (&Delta; _&lambda;_ = 0.5) during the first, natural, pass.

Some other minor changes were made to the example to make it easier to run; e.g. 
* same `newton_tol` in `natural` as in `euler_newton` (for same reason)
* `raise RangeException` to terminate subsequent `euler_newton` continuation after the region of interest has been left
* a five-second pause after the `RangeException`, so that the plot can be inspected (previously there was plenty of time for this)
